### PR TITLE
fix broken link to haskell-modules/lib.nix

### DIFF
--- a/project3/README.md
+++ b/project3/README.md
@@ -518,5 +518,5 @@ If we wanted to get the size down further we'd need to use something like
 This concludes the section on exploring and customizing Haskell packages.  The
 next section covers [simplified dependency management](../project4/README.md).
 
-[haskell-lib]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
+[haskell-lib]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib/default.nix
 [generic-builder]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/generic-builder.nix


### PR DESCRIPTION
(though really I was looking for how to override ghc-options for a dep, like you can in stack.yaml, but it seems there's no such helper?)